### PR TITLE
Homepage - useOnScrollBgColor improvements

### DIFF
--- a/src/containers/Homepage/index.js
+++ b/src/containers/Homepage/index.js
@@ -16,10 +16,10 @@ const Homepage = props => {
   const backgroundColor = useOnScrollBgColor(
     [
       [totalScreenHeight * 0, theme.lightDarkColor],
-      [totalScreenHeight * 0.25, theme.brandDarkRed],
-      [totalScreenHeight * 0.5, theme.brandRed],
-      [totalScreenHeight * 0.75, theme.brandOrange],
-      [totalScreenHeight * 1, theme.brandWhite],
+      [totalScreenHeight * 0.5, theme.brandDarkRed],
+      [totalScreenHeight * 0.75, theme.brandRed],
+      [totalScreenHeight * 1.25, theme.brandOrange],
+      [totalScreenHeight * 1.5, theme.brandWhite],
     ]
   );
 
@@ -45,7 +45,7 @@ Homepage.propTypes = {
 
 const StyledPageWrapper = styled(PageWrapper)`
   color: ${props => props.theme.whiteColor};
-  background-color: ${props => props.backgroundColor || props.theme.lightDarkColor};
+  background-color: ${props => props.backgroundColor};
   transition: all ease 200ms;
 `;
 

--- a/src/utils/hooks/useOnScrollBgColor/index.js
+++ b/src/utils/hooks/useOnScrollBgColor/index.js
@@ -26,8 +26,8 @@ import { mixColors } from 'utils/mixColors';
  * from lower to higher. It defaults to false to save performance.
  * - `setColorOnMount`: Boolean that will run an initial setup during mount to change the background.
  * Defaults to `true`.
- * - `mixRatioChannels`: Supports mixing by specific RBG channels (e.g. only red, or only green and blue).
- * Defaults to mixing all channels.
+ * - `mixRatioChannels`: A 3-Tuple or triple boolean. Supports mixing by specific RBG channels
+ * (e.g. only red, or only green and blue). Defaults to mixing all channels.
  */
 
 export const useOnScrollBgColor = (

--- a/src/utils/hooks/useOnScrollBgColor/index.js
+++ b/src/utils/hooks/useOnScrollBgColor/index.js
@@ -1,5 +1,5 @@
 // Libraries
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 // Dependencies
 import { useThrottle } from 'utils/hooks/useThrottle';
@@ -19,9 +19,11 @@ import { mixColors } from 'utils/mixColors';
  * }} settings Settings, each argument will:
  * - `callback`: Callback which sends the current background color, and the bracket, if any, as arguments.
  * - `scrollHeight`: Total scroll height, defaults to the entire body's height.
- * - `throttleLimit`: Throttle limit, in milliseconds, defaults to 100.
- * - `shouldSort`: shouldSort is a boolean that sorts the `colors` array of tuples by their height breakpoints,
+ * - `throttleLimit`: Throttle limit, in milliseconds, defaults to `100`.
+ * - `shouldSort`: Boolean that sorts the `colors` array of tuples by their height breakpoints,
  * from lower to higher. It defaults to false to save performance.
+ * - `setColorOnMount`: Boolean that will run an initial setup during mount to change the background.
+ * Defaults to `true`.
  */
 
 export const useOnScrollBgColor = (
@@ -30,7 +32,8 @@ export const useOnScrollBgColor = (
     callback,
     scrollHeight = document.body.clientHeight,
     throttleLimit = 100,
-    shouldSort = false
+    shouldSort = false,
+    setColorOnMount = true
   } = {}
   ) => {
   const [backgroundColor, setBackgroundColor] = useState(undefined);
@@ -44,7 +47,7 @@ export const useOnScrollBgColor = (
    * the colors of its upper end and lower end of its bracket. If the scroll position is at the
    * last bracket, no mixing will be made to save performance.
    */
-  const onThrottledScrollHandler = () => {
+  const onThrottledScrollHandler = useCallback(() => {
     const currentScrollHeight = window.pageYOffset;
     const isTupleBreakpoints = Array.isArray(colors[0]);
     /**
@@ -59,9 +62,9 @@ export const useOnScrollBgColor = (
       const colorTwoTuple = colors.find(colorTuple => currentScrollHeight <= colorTuple[0]) || colors[colors.length - 1];
       const indexOfColorTwo = colors.indexOf(colorTwoTuple);
       if (backgroundColor === colorTwoTuple[1]) {
-        const mixedColors = colorTwoTuple[1];
-        setBackgroundColor(mixedColors);
-        if (callback) callback(mixedColors);
+        const mixedColor = colorTwoTuple[1];
+        setBackgroundColor(mixedColor);
+        if (callback) callback(mixedColor);
       } else {
         const colorOneTuple = colors[indexOfColorTwo - 1] || colors[0];
         /**
@@ -69,17 +72,17 @@ export const useOnScrollBgColor = (
          * current scroll height, or position, is at.
          */
         const mixRatio = ((currentScrollHeight - colorOneTuple[0]) / (colorTwoTuple[0] - colorOneTuple[0])) || 0;
-        const mixedColors = mixColors(
+        const mixedColor = mixColors(
           [colorOneTuple[1], colorTwoTuple[1]],
           // Mix ratio is capped at 1, it's redundant
           // since it should never happen, but just in case.
           mixRatio > 1 ? 1 : mixRatio
         );
-        setBackgroundColor(mixedColors);
+        setBackgroundColor(mixedColor);
         /**
-         * On top of sending `mixedColors` as an argument, we send `colorOneTuple`
+         * On top of sending `mixedColor` as an argument, we send `colorOneTuple`
          */
-        if (callback) callback(mixedColors, [colorOneTuple, colorTwoTuple]);
+        if (callback) callback(mixedColor, [colorOneTuple, colorTwoTuple]);
       }
     /**
      * If `colors` is an array of strings, then we simply mix the two colors.
@@ -87,15 +90,17 @@ export const useOnScrollBgColor = (
     } else {
       const [colorOne, colorTwo] = colors;
       const mixRatio = currentScrollHeight / scrollHeight;
-      const mixedColors = mixColors(
+      const mixedColor = mixColors(
         [colorOne, colorTwo],
         // Capped at 1 for whenever `currentScrollHeight` is higher than `scrollHeight`
         mixRatio > 1 ? 1 : mixRatio
       );
-      setBackgroundColor(mixedColors);
-      if (callback) callback(mixedColors);
+      setBackgroundColor(mixedColor);
+      if (callback) callback(mixedColor);
     }
-  };
+  }, [backgroundColor, callback, colors, scrollHeight, shouldSort]);
+
+  const [setupOnMount, setSetupOnMount] = useState(setColorOnMount);
 
   const throttled = useThrottle(onThrottledScrollHandler, throttleLimit);
   useEffect(() => {
@@ -103,8 +108,12 @@ export const useOnScrollBgColor = (
       'scroll',
       throttled
     );
+    if (setupOnMount) {
+      onThrottledScrollHandler();
+      setSetupOnMount(false);
+    }
     return () => window.removeEventListener('scroll', throttled);
-  });
+  }, [throttled, setupOnMount, onThrottledScrollHandler]);
   return backgroundColor;
 };
 

--- a/src/utils/mixColors/index.js
+++ b/src/utils/mixColors/index.js
@@ -27,9 +27,9 @@ const arrayToRgbString = ([A, B, C]) => `rgb(${Number(A).toFixed(0)}, ${Number(B
  * @param {[number, undefined] | [undefined, number]} param2 Set of desired values, at least one has to be known, usually `secondDesiredValue`.
  */
 const linearInterpolation = (
-  [firstValueA, secondValueA], // First set of known values.
-  [firstValueB, secondValueB], // Second set of known values.
-  [firstDesiredValue, secondDesiredValue = undefined] // Set of desired values, at least one has to be known.
+  [firstValueA, secondValueA],
+  [firstValueB, secondValueB],
+  [firstDesiredValue, secondDesiredValue = undefined]
 ) => {
   if (firstDesiredValue !== undefined || firstDesiredValue !== null) {
     return (((secondValueB - secondValueA) / (firstValueB - firstValueA)) * (firstDesiredValue - firstValueA) + secondValueA);


### PR DESCRIPTION
# Description

Added support for an initial setup during the initial mount by using `useCallback` inside `useEffect`.

Also improved comments, and removed the default background color from the `StyledPageWrapper ` component in `Homepage`, the theme `lightDarkColor`.

## Type of the change (mark any which applies)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
